### PR TITLE
DB設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@
 |shipping_fee|integer|null: false|
 |shipping_fee_cost|string|null: false|
 |shipping_days|integer|null: false|
-|user|references|null: false,foreign_key: true|
+|buying_user|references|foreign_key: { to_table: :users }|
+|seller_user|references|null: false,foreign_key: { to_table: :users }|
 |category|references|null: false,foreign_key: true|
 
 ### Association
@@ -83,6 +84,7 @@
 |Column|Type|Options|
 |------|----|-------|
 |name|string|null: false|
+|ancestry|string||
 
 ### Association
 - has_many :items

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@
 |shipping_fee|integer|null: false|
 |shipping_fee_cost|string|null: false|
 |shipping_days|integer|null: false|
-|buying_user|references|foreign_key: { to_table: :users }|
-|seller_user|references|null: false,foreign_key: { to_table: :users }|
+|buyer|references|foreign_key: { to_table: :users }|
+|seller|references|null: false,foreign_key: { to_table: :users }|
 |category|references|null: false,foreign_key: true|
 
 ### Association


### PR DESCRIPTION
# What
READMEへ、DB設計の記述
①itemsのusersテーブルからの外部キーを、sellerとbuyerの二つに変更。
　※カラム名が異なるため、テーブル参照できるよう、オプションを
　　 foreign_key: true →　foreign_key: { to_table: :users } に変更。
②categoriesテーブルにancestryのカラムを追加。

# Why
メンターLGTM後、スプリントレビューにて、再指摘いただいたため、
修正の必要があった。
