### PR TITLE
active_hash(都道府県)の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,3 +71,4 @@ gem 'fog-aws'
 # PAY.JPのgem
 gem 'payjp'
 gem 'ancestry'
+gem 'active_hash'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,8 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_hash (3.1.0)
+      activesupport (>= 5.0.0)
     activejob (5.0.7.2)
       activesupport (= 5.0.7.2)
       globalid (>= 0.3.6)
@@ -267,6 +269,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_hash
   ancestry
   byebug
   capistrano

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,3 +1,6 @@
 class Address < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :prefecture
+
   belongs_to :user
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,7 @@
 class Item < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :shippingfrom
+
   belongs_to :user
   has_many :photos
   belongs_to :category

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,0 +1,20 @@
+class Prefecture < ActiveHash::Base
+  self.data = [
+      {id: 1, name: '北海道'}, {id: 2, name: '青森県'}, {id: 3, name: '岩手県'},
+      {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'}, {id: 6, name: '山形県'},
+      {id: 7, name: '福島県'}, {id: 8, name: '茨城県'}, {id: 9, name: '栃木県'},
+      {id: 10, name: '群馬県'}, {id: 11, name: '埼玉県'}, {id: 12, name: '千葉県'},
+      {id: 13, name: '東京都'}, {id: 14, name: '神奈川県'}, {id: 15, name: '新潟県'},
+      {id: 16, name: '富山県'}, {id: 17, name: '石川県'}, {id: 18, name: '福井県'},
+      {id: 19, name: '山梨県'}, {id: 20, name: '長野県'}, {id: 21, name: '岐阜県'},
+      {id: 22, name: '静岡県'}, {id: 23, name: '愛知県'}, {id: 24, name: '三重県'},
+      {id: 25, name: '滋賀県'}, {id: 26, name: '京都府'}, {id: 27, name: '大阪府'},
+      {id: 28, name: '兵庫県'}, {id: 29, name: '奈良県'}, {id: 30, name: '和歌山県'},
+      {id: 31, name: '鳥取県'}, {id: 32, name: '島根県'}, {id: 33, name: '岡山県'},
+      {id: 34, name: '広島県'}, {id: 35, name: '山口県'}, {id: 36, name: '徳島県'},
+      {id: 37, name: '香川県'}, {id: 38, name: '愛媛県'}, {id: 39, name: '高知県'},
+      {id: 40, name: '福岡県'}, {id: 41, name: '佐賀県'}, {id: 42, name: '長崎県'},
+      {id: 43, name: '熊本県'}, {id: 44, name: '大分県'}, {id: 45, name: '宮崎県'},
+      {id: 46, name: '鹿児島県'}, {id: 47, name: '沖縄県'}
+  ]
+end

--- a/app/models/shippingfrom.rb
+++ b/app/models/shippingfrom.rb
@@ -1,0 +1,20 @@
+class Shippingfrom < ActiveHash::Base
+  self.data = [
+      {id: 1, name: '北海道'}, {id: 2, name: '青森県'}, {id: 3, name: '岩手県'},
+      {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'}, {id: 6, name: '山形県'},
+      {id: 7, name: '福島県'}, {id: 8, name: '茨城県'}, {id: 9, name: '栃木県'},
+      {id: 10, name: '群馬県'}, {id: 11, name: '埼玉県'}, {id: 12, name: '千葉県'},
+      {id: 13, name: '東京都'}, {id: 14, name: '神奈川県'}, {id: 15, name: '新潟県'},
+      {id: 16, name: '富山県'}, {id: 17, name: '石川県'}, {id: 18, name: '福井県'},
+      {id: 19, name: '山梨県'}, {id: 20, name: '長野県'}, {id: 21, name: '岐阜県'},
+      {id: 22, name: '静岡県'}, {id: 23, name: '愛知県'}, {id: 24, name: '三重県'},
+      {id: 25, name: '滋賀県'}, {id: 26, name: '京都府'}, {id: 27, name: '大阪府'},
+      {id: 28, name: '兵庫県'}, {id: 29, name: '奈良県'}, {id: 30, name: '和歌山県'},
+      {id: 31, name: '鳥取県'}, {id: 32, name: '島根県'}, {id: 33, name: '岡山県'},
+      {id: 34, name: '広島県'}, {id: 35, name: '山口県'}, {id: 36, name: '徳島県'},
+      {id: 37, name: '香川県'}, {id: 38, name: '愛媛県'}, {id: 39, name: '高知県'},
+      {id: 40, name: '福岡県'}, {id: 41, name: '佐賀県'}, {id: 42, name: '長崎県'},
+      {id: 43, name: '熊本県'}, {id: 44, name: '大分県'}, {id: 45, name: '宮崎県'},
+      {id: 46, name: '鹿児島県'}, {id: 47, name: '沖縄県'}
+  ]
+end

--- a/db/migrate/20200615083117_create_addresses.rb
+++ b/db/migrate/20200615083117_create_addresses.rb
@@ -6,7 +6,7 @@ class CreateAddresses < ActiveRecord::Migration[5.0]
       t.string      :first_name,           null: false
       t.string      :first_name_reading,   null: false
       t.integer     :postcode,             null: false
-      t.integer     :prefecture,           null: false
+      t.references  :prefecture,           null: false
       t.string      :city,                 null: false
       t.string      :block,                null: false
       t.string      :building

--- a/db/migrate/20200615141120_create_items.rb
+++ b/db/migrate/20200615141120_create_items.rb
@@ -4,11 +4,11 @@ class CreateItems < ActiveRecord::Migration[5.0]
       t.string     :name,              null: false
       t.text       :description,       null: false
       t.string     :size,              null: false
-      t.integer    :status,            null: false
+      t.string     :status,            null: false
       t.integer    :price,             null: false
-      t.integer    :shipping_fee,      null: false
-      t.string     :shipping_fee_cost, null: false
-      t.integer    :shipping_days,     null: false
+      t.string     :shipping_fee,      null: false
+      t.references :shippingfrom,      null: false
+      t.string     :shipping_days,     null: false
       t.references :buyer,                           foreign_key: { to_table: :users }
       t.references :seller,            null: false,  foreign_key: { to_table: :users }
       t.references :category,          null: false,  foreign_key: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 20200615143309) do
     t.string   "first_name",         null: false
     t.string   "first_name_reading", null: false
     t.integer  "postcode",           null: false
-    t.integer  "prefecture",         null: false
+    t.integer  "prefecture_id",      null: false
     t.string   "city",               null: false
     t.string   "block",              null: false
     t.string   "building"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 20200615143309) do
     t.integer  "user_id",            null: false
     t.datetime "created_at",         null: false
     t.datetime "updated_at",         null: false
+    t.index ["prefecture_id"], name: "index_addresses_on_prefecture_id", using: :btree
     t.index ["user_id"], name: "index_addresses_on_user_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -48,22 +48,23 @@ ActiveRecord::Schema.define(version: 20200615143309) do
   end
 
   create_table "items", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name",                            null: false
-    t.text     "description",       limit: 65535, null: false
-    t.string   "size",                            null: false
-    t.integer  "status",                          null: false
-    t.integer  "price",                           null: false
-    t.integer  "shipping_fee",                    null: false
-    t.string   "shipping_fee_cost",               null: false
-    t.integer  "shipping_days",                   null: false
+    t.string   "name",                          null: false
+    t.text     "description",     limit: 65535, null: false
+    t.string   "size",                          null: false
+    t.string   "status",                        null: false
+    t.integer  "price",                         null: false
+    t.string   "shipping_fee",                  null: false
+    t.integer  "shippingfrom_id",               null: false
+    t.string   "shipping_days",                 null: false
     t.integer  "buyer_id"
-    t.integer  "seller_id",                       null: false
-    t.integer  "category_id",                     null: false
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
+    t.integer  "seller_id",                     null: false
+    t.integer  "category_id",                   null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
     t.index ["buyer_id"], name: "index_items_on_buyer_id", using: :btree
     t.index ["category_id"], name: "index_items_on_category_id", using: :btree
     t.index ["seller_id"], name: "index_items_on_seller_id", using: :btree
+    t.index ["shippingfrom_id"], name: "index_items_on_shippingfrom_id", using: :btree
   end
 
   create_table "photos", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|


### PR DESCRIPTION
# what
adressテーブルのprefectureカラムで必要となる都道府県情報をactive_hashを用いて実装する。
また、itemテーブルに関しても、`発送元の地域`項目にて使用する。

# why
都道府県名のように「基本的に変更されないデータ」についてはハッシュとして扱うことが望ましいため。（DBにはハッシュ番号のみ保存される）

# note
active_hashの導入に際し、データベース情報の変更点があります。

`
１）Addressesテーブルのprefectureカラムを、references型に変更
`

`
２）Itemsテーブルの　shipping_fee_costカラム名をshippingfrom　に変更
※「発送元の地域」という項目にそぐわないため。
※カラム名にアンダーバーがあると、activehashの設定がうまくいかないため。
`

`
３）Itemsテーブルの　shippingfromカラムを、references型に変更
`

`
４）Itemsテーブルの　statusカラム＆shipping_feeカラム＆shipping_daysカラム　を、string型に変更
※それぞれ「やや汚れがある」や「出品者が負担」や「1~2日で発送」といった文字列が入るため
`

## 動作確認
https://gyazo.com/b22cbf86e952664b74e6fb2de5cac160