### PR TITLE
Oiso header fotter2

### DIFF
--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -112,14 +112,7 @@
           .product-box__list__body__comment (税込)
 
 -# フッター
-.app-banner
-  .app-banner__contents
-    %h2.app-banner__contents__subtitle だれでもかんたん、人生を変えるフリマアプリ
-    %p.app-banner__contents__text 今すぐ無料ダウンロード！
-    .app-banner__contents__btn
-      = link_to image_tag("Download_on_the_App_Store_Badge_US-UK_RGB_blk_092917.svg", class:"app-banner__contents__btn__abtn"), '#'
-      = link_to image_tag("google-play-badge.png", class:"app-banner__contents__btn__gbtn"), '#'
-
+= render "layouts/footer-banner"
 = render "layouts/footer-links"
 
 -# 出品アイコン

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -3,13 +3,7 @@
 -# メインコンテンツ
 .main
 
-  .main-visual
-    .mv-contents
-      %h2.mv-contents__subtitle 人生を変えるフリマアプリ
-      .mv-contents__text FURIMAはだれでもかんたんに出品・購入できる <br> フリマアプリです
-      .mv-contents__btn
-        = link_to image_tag("Download_on_the_App_Store_Badge_US-UK_RGB_blk_092917.svg", class:"mv-contents__btn__abtn"), '#'
-        = link_to image_tag("google-play-badge.png", class:"mv-contents__btn__gbtn"), '#'
+  = render "layouts/header-banner"
 
   %section.introduction
     %h2.introduction__subtitle FURIMAが選ばれる3つの理由

--- a/app/views/layouts/_footer-banner.html.haml
+++ b/app/views/layouts/_footer-banner.html.haml
@@ -1,0 +1,7 @@
+.app-banner
+  .app-banner__contents
+    %h2.app-banner__contents__subtitle だれでもかんたん、人生を変えるフリマアプリ
+    %p.app-banner__contents__text 今すぐ無料ダウンロード！
+    .app-banner__contents__btn
+      = link_to image_tag("Download_on_the_App_Store_Badge_US-UK_RGB_blk_092917.svg", class:"app-banner__contents__btn__abtn"), '#'
+      = link_to image_tag("google-play-badge.png", class:"app-banner__contents__btn__gbtn"), '#'

--- a/app/views/layouts/_header-banner.html.haml
+++ b/app/views/layouts/_header-banner.html.haml
@@ -1,0 +1,7 @@
+.main-visual
+  .mv-contents
+    %h2.mv-contents__subtitle 人生を変えるフリマアプリ
+    .mv-contents__text FURIMAはだれでもかんたんに出品・購入できる <br> フリマアプリです
+    .mv-contents__btn
+      = link_to image_tag("Download_on_the_App_Store_Badge_US-UK_RGB_blk_092917.svg", class:"mv-contents__btn__abtn"), '#'
+      = link_to image_tag("google-play-badge.png", class:"mv-contents__btn__gbtn"), '#'


### PR DESCRIPTION
# What
header-search, footer-links に加えてheader-bannerとfooter-bannerファイルを作成。
トップページで実装されているHeader(サーチ機能のある部分とappダウンロードのバナー部分）とFooter（appダウンロードのバナー部分とリンク部分）を４分割。

# Why
他のページにて共通するヘッダー、フッターを呼び出しやすくした。