### PR TITLE
本番環境での背景画像が表示されないことへの対応【cssのコードをimage-urlに変更】

### DIFF
--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -124,7 +124,7 @@
   .main-visual {
     width: 100%;
     height: 560px;
-    background-image: url(bg-mainVisual-pict_pc.jpg);
+    background-image: image-url('bg-mainVisual-pict_pc.jpg');
     background-size: cover;
     background-repeat: no-repeat;
     background-position: top center;
@@ -217,7 +217,7 @@
 
   .dl-guide {
     height: 400px;
-    background-image: url(bg-topMiddleDl-pict.jpg);
+    background-image: image-url('bg-topMiddleDl-pict.jpg');
     background-size: cover; 
     background-position: bottom right;
     display: flex;
@@ -348,7 +348,7 @@
 
 // フッター
 .app-banner {
-  background-image: url(bg-appBanner-pict.jpg);
+  background-image: image-url('bg-appBanner-pict.jpg');
   background-size: cover;
   background-position: center;
   padding: 100px 40px 80px 40px;


### PR DESCRIPTION
# What
image-url()というRailsが提供しているアセットパイプラインの機能を使い、
```
background-image: url('画像のファイル名');
```
こちらを
```
background-image: image-url('画像のファイル名');
```
こちらに変更した。

# Why
開発環境では背景画像が表示できていたのに、本番環境で確認してみると背景画像が表示できていなかった。
検証してみると、「404 not found」のエラーが出ている。
調べてみると、可能性としては自動デプロイの際に画像がコンパイルされ、
パスが変わることが原因で起こることが多いとあった。
そのため、urlを指定するのではなく、Railsが指定しているimage-urlメソッドを使ってみた。

# エラー画像
[![Image from Gyazo](https://i.gyazo.com/0e8925888b924f2b4c10a4488afd3ee6.gif)](https://gyazo.com/0e8925888b924f2b4c10a4488afd3ee6)

# メンターさんへ
本番環境でしか、こちらの解決法が正しいのか確認が取れないので、プルリクエスト出させて頂きました。
お手数ですが、こちらの解決法で合っているのかご確認をお願いいたします。