### PR TITLE
遷移リンクの設定【トップページ・ログイン・新規会員登録・支払い方法・ログアウト・商品出品ページ】

### DIFF
--- a/app/assets/stylesheets/header-logo.scss
+++ b/app/assets/stylesheets/header-logo.scss
@@ -1,6 +1,6 @@
 .header-logo {
   width: 100%;
-  height: 150px;
+  height: 130px;
   text-align: center;
   background-color: #EEEEEE;
  

--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -118,8 +118,9 @@
 }
 
 // メイン
-.main {
+.main-toppage {
   background-color: #f8f8f8;
+  padding-top: 0;
 
   .main-visual {
     width: 100%;

--- a/app/assets/stylesheets/users-show.scss
+++ b/app/assets/stylesheets/users-show.scss
@@ -119,15 +119,15 @@
       &__navi {
         background-color: white;
         &__list {
-          display: flex;
+          display: block;
           position: relative;
           min-height: 48px;
           padding: 16px;
           font-size: 14px;
           color: #333;
           border-top: solid 1px #eeeeee;
-          cursor: pointer;
-          .icon {
+          text-decoration: none;
+          &__icon {
             position: absolute;
             top: 50%;
             right: 16px;

--- a/app/assets/stylesheets/users-show.scss
+++ b/app/assets/stylesheets/users-show.scss
@@ -107,6 +107,7 @@
 // メイン
 .main {
   padding-top: 10px;
+  background-color: #f8f8f8;
   &__contents {
     display: flex;
     width: 1020px;

--- a/app/assets/stylesheets/users-signin.scss
+++ b/app/assets/stylesheets/users-signin.scss
@@ -4,7 +4,7 @@
 
   &__header {
     width: 100%;
-    height: 150px;
+    height: 130px;
     background-color: #EEEEEE;
     text-align: center;
     

--- a/app/assets/stylesheets/users-signup.scss
+++ b/app/assets/stylesheets/users-signup.scss
@@ -14,7 +14,7 @@
 
   &__header {
     width: 100%;
-    height: 150px;
+    height: 130px;
     text-align: center;
     background-color: #EEEEEE;
    

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,6 +1,6 @@
 .login-container
   .login-container__header
-    = image_tag 'logo.png', class: 'furima-logo'
+    = render 'layouts/header-logo'
   .login-container__main
     .login-container__main__panel
       .login-container__main__panel__content
@@ -21,14 +21,7 @@
           .login-btn
             = submit_tag "ログイン", class: "btn"
 
-  .login-container__footer
-    %ul.login-container__footer__terms
-      %li= link_to 'プライバシーポリシー', "#"
-      %li= link_to '利用規約', "#"
-      %li= link_to '特定商取引に関する表記', "#"
-
-    .login-container__footer__logo
-      = image_tag 'logo-white.png', class: 'furima-footer-logo'
+  = render "layouts/footer-logo"
 
 
 

--- a/app/views/items/confirm.html.haml
+++ b/app/views/items/confirm.html.haml
@@ -1,7 +1,6 @@
 .item-confirm
   .item-confirm__header
-    = image_tag 'logo.png', class: 'item-new__logo'
-    -# = render "header" をするところ
+    = render 'layouts/header-logo'
   .item-confirm__content
     .item-confirm__content-title 
       %p 購入内容の確認
@@ -28,5 +27,5 @@
         = link_to "変更する", "#"
     .item-confirm__content-confirm
       = button_to "購入する", "#", class: "confirm-btn"
-    .item-confirm__footer
+    = render 'layouts/footer-logo'
       

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -1,7 +1,7 @@
 = render "layouts/header-search"
 
 -# メインコンテンツ
-.main
+.main-toppage
 
   = render "layouts/header-banner"
 

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -110,7 +110,4 @@
 = render "layouts/footer-links"
 
 -# 出品アイコン
-%a{ href: '#' }
-  .sell-btn
-    %span.sell-btn__text 出品する
-    = image_tag 'icon_camera.png', class: 'sell-btn__icon'
+= render "layouts/sell-btn"

--- a/app/views/layouts/_footer-links.html.haml
+++ b/app/views/layouts/_footer-links.html.haml
@@ -27,5 +27,5 @@
           FURIMAロゴ利用ガイドライン <br>
         = link_to '#', class: "footer-content__nav__list" do
           お知らせ
-  = link_to image_tag("logo-white.png", class:"footer-logo"), '/'
+  = link_to image_tag("logo-white.png", class:"footer-logo"), root_path
   .copyright &copy; FURIMA

--- a/app/views/layouts/_footer-links.html.haml
+++ b/app/views/layouts/_footer-links.html.haml
@@ -27,5 +27,5 @@
           FURIMAロゴ利用ガイドライン <br>
         = link_to '#', class: "footer-content__nav__list" do
           お知らせ
-  = link_to image_tag("logo-white.png", class:"footer-logo"), '#'
+  = link_to image_tag("logo-white.png", class:"footer-logo"), '/'
   .copyright &copy; FURIMA

--- a/app/views/layouts/_footer-logo.html.haml
+++ b/app/views/layouts/_footer-logo.html.haml
@@ -5,4 +5,4 @@
     %li= link_to '特定商取引に関する表記', "#"
 
   .account__footer__logo
-    = link_to image_tag("logo-white.png", class:"furima-footer-logo"), '/'
+    = link_to image_tag("logo-white.png", class:"furima-footer-logo"), root_path

--- a/app/views/layouts/_footer-logo.html.haml
+++ b/app/views/layouts/_footer-logo.html.haml
@@ -5,5 +5,4 @@
     %li= link_to '特定商取引に関する表記', "#"
 
   .account__footer__logo
-    -# = image_tag 'logo-white.png', class: 'furima-footer-logo'
     = link_to image_tag("logo-white.png", class:"furima-footer-logo"), '/'

--- a/app/views/layouts/_footer-logo.html.haml
+++ b/app/views/layouts/_footer-logo.html.haml
@@ -5,4 +5,5 @@
     %li= link_to '特定商取引に関する表記', "#"
 
   .account__footer__logo
-    = image_tag 'logo-white.png', class: 'furima-footer-logo'
+    -# = image_tag 'logo-white.png', class: 'furima-footer-logo'
+    = link_to image_tag("logo-white.png", class:"furima-footer-logo"), '/'

--- a/app/views/layouts/_header-logo.html.haml
+++ b/app/views/layouts/_header-logo.html.haml
@@ -1,6 +1,6 @@
 -# ユーザ新規登録/ログインページ・商品出品ページ・商品購入確認ページのheader ここから
 .header-logo
   .header-logo__title
-    = link_to image_tag("logo.png", class:"furima-logo"), '/'
+    = link_to image_tag("logo.png", class:"furima-logo"), root_path
     .header-title1-logo
     .header-title1-text

--- a/app/views/layouts/_header-logo.html.haml
+++ b/app/views/layouts/_header-logo.html.haml
@@ -1,6 +1,7 @@
 -# ユーザ新規登録/ログインページ・商品出品ページ・商品購入確認ページのheader ここから
 .header-logo
   .header-logo__title
-    = image_tag 'logo.png', class: 'furima-logo'
+    -# = image_tag 'logo.png', class: 'furima-logo'
+    = link_to image_tag("logo.png", class:"furima-logo"), '/'
     .header-title1-logo
     .header-title1-text

--- a/app/views/layouts/_header-logo.html.haml
+++ b/app/views/layouts/_header-logo.html.haml
@@ -1,7 +1,6 @@
 -# ユーザ新規登録/ログインページ・商品出品ページ・商品購入確認ページのheader ここから
 .header-logo
   .header-logo__title
-    -# = image_tag 'logo.png', class: 'furima-logo'
     = link_to image_tag("logo.png", class:"furima-logo"), '/'
     .header-title1-logo
     .header-title1-text

--- a/app/views/layouts/_header-search.html.haml
+++ b/app/views/layouts/_header-search.html.haml
@@ -2,7 +2,7 @@
   .header-container
     .main-header
       .furima-logo
-        = link_to image_tag("logo.png", class:"furima-logo"), '/'
+        = link_to image_tag("logo.png", class:"furima-logo"), root_path
       .form
         .search-box
           %input{type: "search", class: "search-box__text", placeholder: "キーワードから探す"}
@@ -20,8 +20,8 @@
         
       %ul.rightlist
         %li.rightlist__conts
-          = link_to '/users/sign_in', class: "" do
+          = link_to user_session_path, class: "" do
             ログイン
         %li.rightlist__conts
-          = link_to '/users/sign_up', class: "" do
+          = link_to new_user_registration_path, class: "" do
             新規会員登録

--- a/app/views/layouts/_header-search.html.haml
+++ b/app/views/layouts/_header-search.html.haml
@@ -20,8 +20,8 @@
         
       %ul.rightlist
         %li.rightlist__conts
-          = link_to '#', class: "" do
+          = link_to '/users/sign_in', class: "" do
             ログイン
         %li.rightlist__conts
-          = link_to '#', class: "" do
+          = link_to '/users/sign_up', class: "" do
             新規会員登録

--- a/app/views/layouts/_header-search.html.haml
+++ b/app/views/layouts/_header-search.html.haml
@@ -2,7 +2,7 @@
   .header-container
     .main-header
       .furima-logo
-        = link_to image_tag("logo.png", class:"furima-logo"), '#'
+        = link_to image_tag("logo.png", class:"furima-logo"), '/'
       .form
         .search-box
           %input{type: "search", class: "search-box__text", placeholder: "キーワードから探す"}

--- a/app/views/layouts/_header-searchlogin.html.haml
+++ b/app/views/layouts/_header-searchlogin.html.haml
@@ -21,5 +21,5 @@
         
       %ul.rightlist
         %li.rightlist__conts
-          = link_to user_path, class: "" do
+          = link_to '/users/show', class: "" do
             マイページ

--- a/app/views/layouts/_header-searchlogin.html.haml
+++ b/app/views/layouts/_header-searchlogin.html.haml
@@ -3,7 +3,7 @@
   .header-container
     .main-header
       .furima-logo
-        = link_to image_tag("logo.png", class:"furima-logo"), '#'
+        = link_to image_tag("logo.png", class:"furima-logo"), '/'
       .form
         .search-box
           %input{type: "search", class: "search-box__text", placeholder: "キーワードから探す"}
@@ -21,5 +21,5 @@
         
       %ul.rightlist
         %li.rightlist__conts
-          = link_to '#', class: "" do
+          = link_to '/users/show', class: "" do
             マイページ

--- a/app/views/layouts/_header-searchlogin.html.haml
+++ b/app/views/layouts/_header-searchlogin.html.haml
@@ -3,7 +3,7 @@
   .header-container
     .main-header
       .furima-logo
-        = link_to image_tag("logo.png", class:"furima-logo"), '/'
+        = link_to image_tag("logo.png", class:"furima-logo"), root_path
       .form
         .search-box
           %input{type: "search", class: "search-box__text", placeholder: "キーワードから探す"}
@@ -21,5 +21,5 @@
         
       %ul.rightlist
         %li.rightlist__conts
-          = link_to '/users/show', class: "" do
+          = link_to user_path, class: "" do
             マイページ

--- a/app/views/layouts/_sell-btn.html.haml
+++ b/app/views/layouts/_sell-btn.html.haml
@@ -1,5 +1,5 @@
 -# 出品アイコン
-= link_to '#', class: "" do
+= link_to '/items/new', class: "" do
   .sell-btn
     %span.sell-btn__text 出品する
     = image_tag 'icon_camera.png', class: 'sell-btn__icon'

--- a/app/views/layouts/_sell-btn.html.haml
+++ b/app/views/layouts/_sell-btn.html.haml
@@ -1,5 +1,5 @@
 -# 出品アイコン
-= link_to '/items/new', class: "" do
+= link_to new_item_path, class: "" do
   .sell-btn
     %span.sell-btn__text 出品する
     = image_tag 'icon_camera.png', class: 'sell-btn__icon'

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -7,11 +7,11 @@
     .main__contents__left
       %ul.main__contents__left__navi
         %li
-          = link_to "/cards/show", class: 'main__contents__left__navi__list' do
+          = link_to card_path, class: 'main__contents__left__navi__list' do
             支払い方法
             = icon('fas', 'angle-right', class: 'main__contents__left__navi__list__icon')
         %li
-          = link_to "/sessions/destroy", class: 'main__contents__left__navi__list' do
+          = link_to sessions_destroy_path, class: 'main__contents__left__navi__list' do
             ログアウト
             = icon('fas', 'angle-right', class: 'main__contents__left__navi__list__icon')
     .main__contents__right

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -6,14 +6,14 @@
   .main__contents
     .main__contents__left
       %ul.main__contents__left__navi
-        %li.main__contents__left__navi__list
-          %p 支払い方法
-          .main__ontents__left__navi__list__icon
-            = icon('fas', 'angle-right', class: 'icon')
-        %li.main__contents__left__navi__list
-          %p ログアウト
-          .main__contents__left__navi__list__icon
-            = icon('fas', 'angle-right', class: 'icon')
+        %li
+          = link_to "/cards/show", class: 'main__contents__left__navi__list' do
+            支払い方法
+            = icon('fas', 'angle-right', class: 'main__contents__left__navi__list__icon')
+        %li
+          = link_to "/sessions/destroy", class: 'main__contents__left__navi__list' do
+            ログアウト
+            = icon('fas', 'angle-right', class: 'main__contents__left__navi__list__icon')
     .main__contents__right
       .main__contents__right__user-icon
         = image_tag 'member_photo_noimage_thumb.png', class: 'user-logo'


### PR DESCRIPTION
# What
#### トップページのメインコンテンツの上部にあるグレー枠の消去
トップページとマイページのmainクラス名が同じであり、SCCを変更すると、マイページにまで影響が出てしまうため、各々クラス名を分けて、それぞれ別のCSSが当たるように調整した。
以下は修正前の画像（mainクラスの上部にpadding-top: 10px;が当たってしまっている）
![image](https://user-images.githubusercontent.com/63178924/85918756-6ced7180-b8a0-11ea-9316-9ef3b3282956.png)

#### ログインページと商品購入確認ページのヘッターやフッターを、部分テンプレートに変更
上記のページにだけ部分テンプレートが外れてしまっていたため、部分テンプレートに差し替えを行った。

#### 各種リンクを設定
1.トップページ上部の「ログイン」「新規会員登録」に各種ページへの遷移リンクを設定。
2.トップページとマイページにある出品ボタン（部分テンプレート）に、商品出品ページへ遷移するリンクを設定。
3.ヘッターとフッターにある「FURIMAロゴ」に、トップページへ遷移するリンクを設定。
4.マイページの「支払い方法」「ログアウト」に各種ページへの遷移リンクを設定。

# Why
各種ビューの作成時は、リンク先を「'#'」にしていたため、リンクを設定することで、直接、ログイン・新規登録ページやトップページにの遷移できるようにし、ユーザビリティを高めた。
また、各々が実装したページをmasterブランチにマージした際に、クラス名が一致したものがあったことで一部ビューが崩れてしまった部分があったため、そちらの修正を行った。

[![Image from Gyazo](https://i.gyazo.com/b9a907b0693e08f6023a591571712343.gif)](https://gyazo.com/b9a907b0693e08f6023a591571712343)

[![Image from Gyazo](https://i.gyazo.com/be55609767141d2d75a428a74e72180b.gif)](https://gyazo.com/be55609767141d2d75a428a74e72180b)

[![Image from Gyazo](https://i.gyazo.com/1ff41a66585f658bdf9f0248e51d8316.gif)](https://gyazo.com/1ff41a66585f658bdf9f0248e51d8316)