### PR TITLE
ユーザマイページからの遷移先追加

### DIFF
--- a/app/views/cards/confirm.html.haml
+++ b/app/views/cards/confirm.html.haml
@@ -14,7 +14,7 @@
           .card-index__container__inner__btn__box__icon
             = icon('fas', 'credit-card', class: 'icon')
           .card-index__container__inner__btn__box__add
-            = link_to '/cards/new', class: "" do
+            = link_to new_card_path, class: "" do
               %p クレジットカードを追加する
         
 -# バナー

--- a/app/views/cards/confirm.html.haml
+++ b/app/views/cards/confirm.html.haml
@@ -14,7 +14,7 @@
           .card-index__container__inner__btn__box__icon
             = icon('fas', 'credit-card', class: 'icon')
           .card-index__container__inner__btn__box__add
-            = link_to '#', class: "" do
+            = link_to '/cards/new', class: "" do
               %p クレジットカードを追加する
         
 -# バナー

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -67,7 +67,7 @@
             .card-new__container__info__inner__form__security__code
               = text_field_tag  "payment_card_cvc", "", type: 'text', class: 'security-number',  maxlength: "4", placeholder: 'カード背面4桁もしくは3桁の番号'
  
-          -# 追加するボタン
+          -# 追加するボタン linkはユーザID等の機能未実装のためprefix未設定(実装後はlink_to card_path,)となる
           .card-new__container__info__inner__form__add 
             = link_to '/cards/show', class: "add-btn" do
               %p 追加する

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -69,7 +69,7 @@
  
           -# 追加するボタン
           .card-new__container__info__inner__form__add 
-            = link_to '#', class: "add-btn" do
+            = link_to '/cards/show', class: "add-btn" do
               %p 追加する
 
 -# バナー

--- a/app/views/cards/show.html.haml
+++ b/app/views/cards/show.html.haml
@@ -19,7 +19,7 @@
             .card-show__container__inner__btn__box__info__data
               %p 12/20
           .card-show__container__inner__btn__box__delete
-            = link_to '#', class: "" do
+            = link_to '/cards/1/confirm', class: "" do
               %p 削除する
         
 -# バナー

--- a/app/views/cards/show.html.haml
+++ b/app/views/cards/show.html.haml
@@ -19,7 +19,7 @@
             .card-show__container__inner__btn__box__info__data
               %p 12/20
           .card-show__container__inner__btn__box__delete
-            = link_to '/cards/1/confirm', class: "" do
+            = link_to confirm_card_path, class: "" do
               %p 削除する
         
 -# バナー

--- a/app/views/sessions/destroy.html.haml
+++ b/app/views/sessions/destroy.html.haml
@@ -5,7 +5,7 @@
 .user-logout
   .user-logout__container
     .user-logout__container__btn 
-      = link_to '#', class: "" do
+      = link_to root_path, class: "" do
         %p ログアウト
         
 -# バナー

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -7,7 +7,7 @@
     .main__contents__left
       %ul.main__contents__left__navi
         %li
-          = link_to card_path, class: 'main__contents__left__navi__list' do
+          = link_to '/cards/1/confirm', class: 'main__contents__left__navi__list' do
             支払い方法
             = icon('fas', 'angle-right', class: 'main__contents__left__navi__list__icon')
         %li

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -7,7 +7,7 @@
     .main__contents__left
       %ul.main__contents__left__navi
         %li
-          = link_to '/cards/1/confirm', class: 'main__contents__left__navi__list' do
+          = link_to confirm_card_path, class: 'main__contents__left__navi__list' do
             支払い方法
             = icon('fas', 'angle-right', class: 'main__contents__left__navi__list__icon')
         %li


### PR DESCRIPTION
# what
ユーザマイページから
①クレジットカード登録系画面系へのリンク仮記載
②ユーザログアウトページへのリンク仮記載

view間の仮リンク追加のためprefixは未設定箇所あり
ユーザログイン機能等未実装のため

# why
ユーザマイページからの遷移先が"#"の状態であったため
各view確認時用にリンクの仮設定をする必要があった。

ユーザマイページ→クレジット未登録画面→クレジット登録画面→クレジット登録済画面
[![Screenshot from Gyazo](https://gyazo.com/735e09dca3a7cab69c2ff49a49e994d7/raw)](https://gyazo.com/735e09dca3a7cab69c2ff49a49e994d7)

ユーザマイページ→ログアウトページ→トップページ
[![Screenshot from Gyazo](https://gyazo.com/5327640f07f77a4cdae9bb15add72e71/raw)](https://gyazo.com/5327640f07f77a4cdae9bb15add72e71)