### PR TITLE
カテゴリ機能(商品詳細ページ)

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -41,6 +41,9 @@ class ItemsController < ApplicationController
   def show
     @first_photo = @item.photos[0]
     @photos = @item.photos.all
+    @product = Item.find(params[:id])
+    @parents = Category.all
+
   end
 
   def edit

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -27,7 +27,7 @@
           %td.column
             カテゴリー
           %td.info
-            -# = @item.category.name
+            -# = @item.category.nameあ
             
         %tr
           %td.column

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -27,8 +27,13 @@
           %td.column
             カテゴリー
           %td.info
-            -# = @item.category.nameあ
-            
+            - @parents.each do |parent|
+              - if @product.category_id == parent.id
+                = parent.parent.parent.name
+                %br
+                = parent.parent.name
+                %br
+                = parent.name
         %tr
           %td.column
             商品のサイズ


### PR DESCRIPTION
# what
商品詳細表示画面で登録した商品の親・子・孫の
カテゴリーを表示させた
# why
商品詳細表示画面で登録した商品の親・子・孫の
カテゴリーが見たいユーザのため実装

トップページ→商品詳細ページに遷移
テスト様を選択した時にカテゴリ欄が親・子・孫を表示できている
itemsテーブルのcategory_id 14の商品なので
categoriesテーブルのid14のメンズ(親)＞トップス(子)＞Tシャツ/カットソー(半袖/袖なし)(孫)が表示できればOK
[![Screenshot from Gyazo](https://gyazo.com/a43ef9535f4286e448d62c396c866373/raw)](https://gyazo.com/a43ef9535f4286e448d62c396c866373)
[![Screenshot from Gyazo](https://gyazo.com/5c7d9269536845b135fd827de1d3fecd/raw)](https://gyazo.com/5c7d9269536845b135fd827de1d3fecd)
[![Screenshot from Gyazo](https://gyazo.com/a6a3fab42b78ef2d0d49107f30f8e5d8/raw)](https://gyazo.com/a6a3fab42b78ef2d0d49107f30f8e5d8)
