### PR TITLE
商品購入機能　payjp.js5行目の公開鍵直書きを環境変数入力に修正　-umezawa

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,3 +88,5 @@ gem 'active_hash'
 # 環境変数を簡単に定義できるENVファイルを対応させるgem
 gem 'dotenv-rails'
 gem 'rails-i18n'
+# 環境変数出力gem 0808追加
+gem 'gon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,11 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gon (6.3.2)
+      actionpack (>= 3.0.20)
+      i18n (>= 0.7)
+      multi_json
+      request_store (>= 1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -237,6 +242,8 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (1.7.1)
+    request_store (1.5.0)
+      rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -344,6 +351,7 @@ DEPENDENCIES
   faker
   fog-aws
   font-awesome-sass
+  gon
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -1,7 +1,12 @@
 document.addEventListener(
   "DOMContentLoaded", e => {
     if (document.getElementById("token_submit") != null) {    //token_submitというidがnullの場合、下記コードを実行しない
-      Payjp.setPublicKey("pk_test_f6455466f758b3261b7e8af5");     //公開鍵を直書き
+      
+      // Payjp.setPublicKey('pk_test_f6455466f758b3261b7e8af5') //公開鍵を直書き.旧記載
+
+      const KEY = gon.PAYJP_KEY;// 公開鍵は環境変数から取得
+      Payjp.setPublicKey(KEY) //公開鍵をセット
+
       let btn = document.getElementById("token_submit");    //IDがtoken_submitの場合に取得される
       btn.addEventListener("click", e => {    //ボタンが押された時に作動
         e.preventDefault();     //ボタンを一旦無効化する

--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -1,7 +1,7 @@
 document.addEventListener(
   "DOMContentLoaded", e => {
     if (document.getElementById("token_submit") != null) {    //token_submitというidがnullの場合、下記コードを実行しない
-      Payjp.setPublicKey("pk_test_c064df03b17ed93cc8099538");     //公開鍵を直書き
+      Payjp.setPublicKey("pk_test_f6455466f758b3261b7e8af5");     //公開鍵を直書き
       let btn = document.getElementById("token_submit");    //IDがtoken_submitの場合に取得される
       btn.addEventListener("click", e => {    //ボタンが押された時に作動
         e.preventDefault();     //ボタンを一旦無効化する

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -4,6 +4,7 @@ class CardsController < ApplicationController
 
   def new
     @card = Card.new
+    gon.PAYJP_KEY = ENV['PAYJP_KEY']
   end
 
   def create
@@ -33,6 +34,8 @@ class CardsController < ApplicationController
       end
     end
   end
+
+
 
   def show        #cardのデータをpayjpに送り、情報を取り出す
     @card = Card.where(user: current_user.id).first

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -1,47 +1,47 @@
-# # 購入機能controller
-# class PurchaseController < ApplicationController
+# 購入機能controller
+class PurchaseController < ApplicationController
 
-#   require 'payjp'
+  require 'payjp'
 
-#   def index
-#     # 購入する商品を引っ張ってくる
-#     @item = Item.find(params[:id])
-#     # 商品ごとに複数枚写真を登録出来るので、全部取ってくる
-#     # @image = @item.images.all
+  def index
+    # 購入する商品を引っ張ってくる
+    @item = Item.find(params[:id])
+    # 商品ごとに複数枚写真を登録出来るので、全部取ってくる
+    # @image = @item.images.all
 
     
-#     @card = Card.find_by(user_id: current_user.id)
-#     #テーブルからpayjpの顧客IDを検索
-#     if @card.blank?
-#       #登録された情報がない場合にカード登録画面に移動
-#       redirect_to controller: "card", action: "new"
-#     else
-#       Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
-#       #保管した顧客IDでpayjpから情報取得
-#       customer = Payjp::Customer.retrieve(@card.customer_id)
-#       #保管したカードIDでpayjpから情報取得、カード情報表示のためインスタンス変数に代入
-#       @default_card_information = customer.cards.retrieve(customer.default_card)
-#       # 表示文字数変更処理
-#       @last4 = @default_card_information.last4
-#       @exp_month = @default_card_information.exp_month.to_s.rjust(2, '0')
-#       @exp_year = @default_card_information.exp_year.to_s.slice(2, 2)
+    @card = Card.find_by(user_id: current_user.id)
+    #テーブルからpayjpの顧客IDを検索
+    if @card.blank?
+      #登録された情報がない場合にカード登録画面に移動
+      redirect_to controller: "card", action: "new"
+    else
+      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+      #保管した顧客IDでpayjpから情報取得
+      customer = Payjp::Customer.retrieve(@card.customer_id)
+      #保管したカードIDでpayjpから情報取得、カード情報表示のためインスタンス変数に代入
+      @default_card_information = customer.cards.retrieve(customer.default_card)
+      # 表示文字数変更処理
+      @last4 = @default_card_information.last4
+      @exp_month = @default_card_information.exp_month.to_s.rjust(2, '0')
+      @exp_year = @default_card_information.exp_year.to_s.slice(2, 2)
 
-#       @item = Item.find_by(id: params[:id])
-#       @name = @item.name
-#       @price = @item.price
-#       @shipp = @item.shipping_fee
-#     end
-#   end
+      @item = Item.find_by(id: params[:id])
+      @name = @item.name
+      @price = @item.price
+      @shipp = @item.shipping_fee
+    end
+  end
 
-#   def pay
-#     @card = Card.find_by(user_id: current_user.id)
-#     Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
-#     Payjp::Charge.create(
-#       amount: @price, #支払金額を入力（itemテーブル等に紐づけても良い）
-#       customer: Payjp::Customer.retrieve(@card.customer_id), #顧客ID
-#       currency: 'jpy'  #日本円
-#     )
-#   redirect_to action: 'done' #完了画面に移動
-#   end
+  def pay
+    @card = Card.find_by(user_id: current_user.id)
+    Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
+    Payjp::Charge.create(
+      amount: @price, #支払金額を入力（itemテーブル等に紐づけても良い）
+      customer: Payjp::Customer.retrieve(@card.customer_id), #顧客ID
+      currency: 'jpy'  #日本円
+    )
+  redirect_to action: 'done' #完了画面に移動
+  end
 
-# end
+end

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -25,8 +25,6 @@ class PurchaseController < ApplicationController
       @last4 = @default_card_information.last4
       @exp_month = @default_card_information.exp_month.to_s.rjust(2, '0')
       @exp_year = @default_card_information.exp_year.to_s.slice(2, 2)
-
-      @item = Item.find_by(id: params[:id])
       @name = @item.name
       @price = @item.price
       @shipp = @item.shipping_fee

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -66,8 +66,8 @@
           = button_to "商品の編集", edit_item_path(@item.id), method: :get,class: "confirm-btn"
           = button_to "商品の削除", item_path(@item.id), method: :delete,class: "confirm-btn"
         - elsif user_signed_in? && @item.seller.id != current_user.id
-          = button_to "購入画面に進む", purchase_path(@item.id), class: "confirm-btn"
           -# = button_to "購入画面に進む", "#", class: "confirm-btn"
+          = button_to "購入画面に進む", purchase_path(@item.id), class: "confirm-btn"
 
 = render "layouts/footer-banner"
 = render "layouts/footer-links"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -66,8 +66,8 @@
           = button_to "商品の編集", edit_item_path(@item.id), method: :get,class: "confirm-btn"
           = button_to "商品の削除", item_path(@item.id), method: :delete,class: "confirm-btn"
         - elsif user_signed_in? && @item.seller.id != current_user.id
-          = button_to "購入画面に進む", "#", class: "confirm-btn"
-          -# = button_to "購入画面に進む", purchase_path(@item.id), class: "confirm-btn"
+          = button_to "購入画面に進む", purchase_path(@item.id), class: "confirm-btn"
+          -# = button_to "購入画面に進む", "#", class: "confirm-btn"
 
 = render "layouts/footer-banner"
 = render "layouts/footer-links"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,6 +4,7 @@
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title FleamarketSample72d
     = csrf_meta_tags
+    = include_gon
     = stylesheet_link_tag    'application'
     = javascript_include_tag 'application'
     %script{src: "https://js.pay.jp/", type: "text/javascript"}

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -1,10 +1,10 @@
-%h2 購入を確定しますか？
-%p #{@name}
-%p ¥ #{@price} #{@shipp}
-%br
-%h3 支払い方法
-%p **** **** **** #{@last4}
-%p #{@exp_month} / #{@exp_year}
-%br
-= form_tag(action: :pay, method: :post) do
-  = link_to "購入する", root_path, class: ""
+-# %h2 購入を確定しますか？
+-# %p #{@name}
+-# %p ¥ #{@price} #{@shipp}
+-# %br
+-# %h3 支払い方法
+-# %p **** **** **** #{@last4}
+-# %p #{@exp_month} / #{@exp_year}
+-# %br
+-# = form_tag(action: :pay, method: :post) do
+-#   = link_to "購入する", root_path, class: ""

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -1,10 +1,10 @@
--# %h2 購入を確定しますか？
--# %p #{@name}
--# %p ¥ #{@price} #{@shipp}
--# %br
--# %h3 支払い方法
--# %p **** **** **** #{@last4}
--# %p #{@exp_month} / #{@exp_year}
--# %br
--# = form_tag(action: :pay, method: :post) do
--#   = link_to "購入する", root_path, class: ""
+%h2 購入を確定しますか？
+%p #{@name}
+%p ¥ #{@price} #{@shipp}
+%br
+%h3 支払い方法
+%p **** **** **** #{@last4}
+%p #{@exp_month} / #{@exp_year}
+%br
+= form_tag(action: :pay, method: :post) do
+  = link_to "購入する", root_path, class: ""

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -27,6 +27,8 @@ set :keep_releases, 5
 
 # secrets.yml用のシンボリックリンクを追加
 set :linked_files, %w{ config/secrets.yml }
+# set :linked_files, %w{ .env }
+
 
 # デプロイ処理が終わった後、Unicornを再起動するための記述
 after 'deploy:publishing', 'deploy:restart'
@@ -42,6 +44,8 @@ namespace :deploy do
         execute "mkdir -p #{shared_path}/config"
       end
       upload!('config/secrets.yml', "#{shared_path}/config/secrets.yml")
+      # upload!('.env', "#{shared_path}/.env")
+
     end
   end
   before :starting, 'deploy:upload'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -27,7 +27,7 @@ set :keep_releases, 5
 
 # secrets.yml用のシンボリックリンクを追加
 set :linked_files, %w{ config/secrets.yml }
-# set :linked_files, %w{ .env }
+# 後の機能で使用する予定のため残しています set :linked_files, %w{ .env }
 
 
 # デプロイ処理が終わった後、Unicornを再起動するための記述
@@ -44,7 +44,7 @@ namespace :deploy do
         execute "mkdir -p #{shared_path}/config"
       end
       upload!('config/secrets.yml', "#{shared_path}/config/secrets.yml")
-      # upload!('.env', "#{shared_path}/.env")
+      # 後の機能で使用する予定のため残しています upload!('.env', "#{shared_path}/.env")
 
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,11 +30,11 @@ Rails.application.routes.draw do
         get 'confirm'
       end
     end
-    # resources :purchase, only: [:index] do
-    #   member do
-    #     post 'index'
-    #     get 'pay'
-    #   end
-    # end
+    resources :purchase, only: [:index] do
+      member do
+        post 'index'
+        get 'pay'
+      end
+    end
     get 'sessions/destroy'
 end


### PR DESCRIPTION
# What
payjp.js5行目の公開鍵を直打ち記載(Payjp.setPublicKey('pk_test_f6〜'))していたのを
環境変数を取得し反映する方式に変更
**-----
**①gem ‘gon’を「Gemfile」の一番下に追記しbundle install
②layouts/application.heml.haml　の7行目辺りに
  = include_gon
を追記
③cards_controller　の7行目に
gon.PAYJP_KEY = ENV[‘PAYJP_KEY’]
を追記
④payjp.js 
5行目の
Payjp.setPublicKey('pk_test_f6455466f758b3261b7e8af5') 
の記載を
7,8行目の
const KEY = gon.PAYJP_KEY;
Payjp.setPublicKey(KEY) 
に修正**
-----**
# Why
payjpへのアクセスキーをコード上に残しておくのはセキュリティ上よくないので修正

[![Screenshot from Gyazo](https://gyazo.com/650c9ef024c9bf89293e76020a274093/raw)](https://gyazo.com/650c9ef024c9bf89293e76020a274093)